### PR TITLE
feat: BE의 submissionId 사용 및 Judge0 worker 자동 실행

### DIFF
--- a/app/application/services/eval_service.py
+++ b/app/application/services/eval_service.py
@@ -384,6 +384,7 @@ class EvalService:
         spec_id: int,
         code_content: str,
         lang: str = "python",
+        submission_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         코드 제출 및 최종 평가
@@ -395,6 +396,7 @@ class EvalService:
             spec_id: 문제 스펙 ID
             code_content: 제출 코드
             lang: 프로그래밍 언어
+            submission_id: BE에서 생성한 제출 ID (Optional)
         
         Returns:
             평가 결과
@@ -408,6 +410,8 @@ class EvalService:
             existing_state["is_submitted"] = True
             existing_state["code_content"] = code_content
             existing_state["lang"] = lang
+            if submission_id:
+                existing_state["submission_id"] = submission_id
         else:
             # 초기 상태 생성
             state = get_initial_state(
@@ -420,6 +424,8 @@ class EvalService:
             state["is_submitted"] = True
             state["code_content"] = code_content
             state["lang"] = lang
+            if submission_id:
+                state["submission_id"] = submission_id
             existing_state = state
         
         # 그래프 실행

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     
     # PostgreSQL 설정 (Spring Boot와 공유)
     POSTGRES_HOST: str = "localhost"
-    POSTGRES_PORT: int = 5432
+    POSTGRES_PORT: int = 5435  # Docker 컨테이너 포트 매핑: 5435:5432
     POSTGRES_USER: str = "postgres"
     POSTGRES_PASSWORD: str = "postgres"
     POSTGRES_DB: str = "ai_vibe_coding_test"
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
     
     # Redis 설정 (세션 상태 관리)
     REDIS_HOST: str = "localhost"
-    REDIS_PORT: int = 6379
+    REDIS_PORT: int = 6378
     REDIS_PASSWORD: Optional[str] = None
     REDIS_DB: int = 0
     

--- a/app/domain/langgraph/nodes/holistic_evaluator/scores.py
+++ b/app/domain/langgraph/nodes/holistic_evaluator/scores.py
@@ -186,41 +186,33 @@ async def aggregate_final_scores(state: MainGraphState) -> Dict[str, Any]:
                     submission_repo = SubmissionRepository(db)
                     session_repo = SessionRepository(db)
                     
-                    # 1. Submission 생성 또는 조회
+                    # 1. Submission 조회 및 업데이트
+                    # BE에서 생성한 submission을 사용하므로, submission_id가 반드시 있어야 함
                     if not submission_id:
-                        # 코드 해시 계산
-                        code_sha256 = hashlib.sha256(code_content.encode('utf-8')).hexdigest()
-                        code_bytes = len(code_content.encode('utf-8'))
-                        code_loc = len(code_content.splitlines())
-                        
-                        # lang 기본값 (State에 없으면 "python")
-                        lang = state.get("lang", "python")
-                        
-                        submission = await submission_repo.create_submission(
-                            exam_id=exam_id,
-                            participant_id=participant_id,
-                            spec_id=spec_id,
-                            lang=lang,
-                            code_inline=code_content,
-                            code_sha256=code_sha256,
-                            code_bytes=code_bytes,
-                            code_loc=code_loc
+                        logger.error(
+                            f"[7. Aggregate Final Scores] Submission ID가 없습니다 - "
+                            f"exam_id: {exam_id}, participant_id: {participant_id}"
                         )
-                        submission_id = submission.id
-                        logger.info(
-                            f"[7. Aggregate Final Scores] Submission 생성 완료 - "
+                        raise ValueError("Submission ID is required. BE에서 생성한 submission ID가 전달되어야 합니다.")
+                    
+                    # 기존 submission 조회 및 상태 업데이트
+                    submission = await submission_repo.get_submission_by_id(submission_id)
+                    if not submission:
+                        logger.error(
+                            f"[7. Aggregate Final Scores] Submission을 찾을 수 없습니다 - "
                             f"submission_id: {submission_id}, exam_id: {exam_id}, participant_id: {participant_id}"
                         )
-                    else:
-                        # 기존 submission 상태 업데이트
-                        await submission_repo.update_submission_status(
-                            submission_id=submission_id,
-                            status=SubmissionStatusEnum.DONE
-                        )
-                        logger.info(
-                            f"[7. Aggregate Final Scores] Submission 상태 업데이트 완료 - "
-                            f"submission_id: {submission_id}, status: DONE"
-                        )
+                        raise ValueError(f"Submission not found: submission_id={submission_id}")
+                    
+                    # submission 상태 업데이트
+                    await submission_repo.update_submission_status(
+                        submission_id=submission_id,
+                        status=SubmissionStatusEnum.DONE
+                    )
+                    logger.info(
+                        f"[7. Aggregate Final Scores] Submission 상태 업데이트 완료 - "
+                        f"submission_id: {submission_id}, status: DONE"
+                    )
                     
                     # 2. Score 저장
                     score = await submission_repo.create_or_update_score(

--- a/app/infrastructure/persistence/models/exams.py
+++ b/app/infrastructure/persistence/models/exams.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.infrastructure.persistence.session import Base
-from app.infrastructure.persistence.models.enums import ExamStateEnum, ExamParticipantStateEnum
+from app.infrastructure.persistence.models.enums import ExamStateEnum
 
 
 class Exam(Base):
@@ -88,17 +88,17 @@ class ExamParticipant(Base):
         ForeignKey("participants.id"),
         nullable=False
     )
-    state: Mapped[ExamParticipantStateEnum] = mapped_column(
-        Enum(ExamParticipantStateEnum, name="ai_vibe_coding_test.exam_state_enum"),
+    state: Mapped[str] = mapped_column(
+        String(20),
         nullable=False,
-        default=ExamParticipantStateEnum.REGISTERED
+        default="ACTIVE"
     )
-    token_limit: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    token_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     token_used: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    spec_id: Mapped[Optional[int]] = mapped_column(
+    spec_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("problem_specs.id"),
-        nullable=True
+        nullable=False
     )
     joined_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True),

--- a/app/infrastructure/repositories/exam_repository.py
+++ b/app/infrastructure/repositories/exam_repository.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from app.infrastructure.persistence.models.exams import Exam, ExamParticipant, ExamStatistics
 from app.infrastructure.persistence.models.problems import ProblemSpec
-from app.infrastructure.persistence.models.enums import ExamStateEnum, ExamParticipantStateEnum
+from app.infrastructure.persistence.models.enums import ExamStateEnum
 
 
 class ExamRepository:
@@ -65,7 +65,7 @@ class ExamRepository:
         self,
         exam_id: int,
         participant_id: int,
-        state: ExamParticipantStateEnum
+        state: str
     ) -> Optional[ExamParticipant]:
         """참가자 상태 업데이트"""
         participant = await self.get_exam_participant(exam_id, participant_id)
@@ -98,9 +98,7 @@ class ExamRepository:
         if participant is None:
             return False
         
-        if participant.token_limit is None:
-            return True  # 제한 없음
-        
+        # token_limit는 NOT NULL DEFAULT 0이므로 None 체크 불필요
         return (participant.token_used + required_tokens) <= participant.token_limit
     
     async def get_exam_statistics(self, exam_id: int) -> Optional[ExamStatistics]:

--- a/app/presentation/schemas/chat.py
+++ b/app/presentation/schemas/chat.py
@@ -90,9 +90,10 @@ class SubmitCodeRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "examId": 1,
+                "participantId": 1,
                 "problemId": 1,
-                "specVersion": 1,
-                "examParticipantId": 9001,
+                "specId": 1,
                 "finalCode": "def solve():\n    print('hello')",
                 "language": "python3.11",
                 "submissionId": 88001
@@ -100,9 +101,10 @@ class SubmitCodeRequest(BaseModel):
         }
     )
     
+    examId: int = Field(..., description="시험 ID")
+    participantId: int = Field(..., description="참가자 ID (participants.id)")
     problemId: int = Field(..., description="문제 ID")
-    specVersion: int = Field(..., description="스펙 버전")
-    examParticipantId: int = Field(..., description="참가자 식별값")
+    specId: int = Field(..., description="스펙 ID (problem_specs.id)")
     finalCode: str = Field(..., description="제출 코드")
     language: str = Field(..., description="프로그래밍 언어 (예: python3.11)")
     submissionId: int = Field(..., description="제출 ID (백엔드에서 생성)")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
     image: redis:7-alpine
     container_name: ai_vibe_redis_dev
     ports:
-      - "6379:6379"
+      - "6378:6379"
     volumes:
       - redis_dev_data:/data
     healthcheck:
@@ -42,7 +42,7 @@ services:
     image: adminer:latest
     container_name: ai_vibe_adminer_dev
     ports:
-      - "8080:8080"
+      - "8081:8081"
     depends_on:
       - postgres
     environment:

--- a/scripts/run_dev.py
+++ b/scripts/run_dev.py
@@ -1,15 +1,48 @@
 #!/usr/bin/env python
 """
 개발 서버 실행 스크립트
+FastAPI 서버와 Judge0 Worker를 함께 실행
 """
 import os
 import sys
+import asyncio
+import logging
+from threading import Thread
 
 # 프로젝트 루트를 Python 경로에 추가
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-if __name__ == "__main__":
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def run_judge_worker():
+    """Judge0 Worker를 별도 스레드에서 실행"""
+    async def worker_main():
+        try:
+            from app.application.workers.judge_worker import main as judge_main
+            await judge_main()
+        except KeyboardInterrupt:
+            logger.info("[JudgeWorker] Worker 중지 요청 수신")
+        except Exception as e:
+            logger.error(f"[JudgeWorker] Worker 오류: {str(e)}", exc_info=True)
+    
+    try:
+        # 스레드에서 새로운 이벤트 루프 생성
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(worker_main())
+    except Exception as e:
+        logger.error(f"[JudgeWorker] Worker 실행 실패: {str(e)}", exc_info=True)
+
+
+def run_uvicorn():
+    """Uvicorn 서버 실행"""
     import uvicorn
     from dotenv import load_dotenv
     
@@ -23,4 +56,19 @@ if __name__ == "__main__":
         reload=True,
         log_level="debug",
     )
+
+
+if __name__ == "__main__":
+    # Judge0 Worker를 백그라운드 스레드에서 실행
+    judge_worker_thread = Thread(target=run_judge_worker, daemon=True)
+    judge_worker_thread.start()
+    logger.info("[Dev Server] Judge0 Worker 시작됨")
+    
+    # FastAPI 서버 실행 (메인 스레드)
+    try:
+        run_uvicorn()
+    except KeyboardInterrupt:
+        logger.info("[Dev Server] 서버 종료 요청 수신")
+    except Exception as e:
+        logger.error(f"[Dev Server] 서버 실행 오류: {str(e)}", exc_info=True)
 


### PR DESCRIPTION
- BE에서 생성한 submissionId를 사용하도록 수정
  - eval_service.submit_code()에 submission_id 파라미터 추가
  - aggregate_final_scores에서 BE의 submission 조회 후 상태만 업데이트
  - AI 서버에서 submission을 새로 생성하지 않음

- Judge0 worker 자동 실행
  - run_dev.py에서 FastAPI 서버와 함께 Judge0 worker 실행
  - 백그라운드 스레드에서 worker 실행

- submissions 테이블 unique constraint 추가
  - init-db.sql에 UNIQUE(exam_id, participant_id) 추가
  - 한 참가자는 한 번만 제출 가능

- ExamParticipant 모델 수정
  - spec_id, state, token_limit 필드 타입 수정 (BE와 일치)
  - ExamParticipantStateEnum 제거, state를 str로 변경